### PR TITLE
Changed default salt and hash constants to rely on environment variables

### DIFF
--- a/web/content/mu-plugins/wp_lagoon_configuration.php
+++ b/web/content/mu-plugins/wp_lagoon_configuration.php
@@ -1,0 +1,56 @@
+<?php
+
+/**
+ * Plugin Name: WP Lagoon Configuration
+ * Description: Checks for necessary environment variables and displays admin notices if they're missing.
+ * Version: 1.0
+ * Author: Salsa Digital (ivan.grynenko@salsa.digital)
+ */
+
+function wp_lagoon_config_admin_notices() {
+  // Only show this error to administrators.
+  if (!current_user_can('manage_options')) {
+    return;
+  }
+
+  $messages = [];
+
+  if (defined('WP_MISSING_AUTH_KEY') && WP_MISSING_AUTH_KEY) {
+    $messages[] = 'Error: Add WP_AUTH_KEY variable to the list of variables - via the .env file or by other means.';
+  }
+
+  if (defined('WP_MISSING_SECURE_AUTH_KEY') && WP_MISSING_SECURE_AUTH_KEY) {
+    $messages[] = 'Error: Add WP_SECURE_AUTH_KEY variable to the list of variables - via the .env file or by other means.';
+  }
+
+  if (defined('WP_MISSING_LOGGED_IN_KEY') && WP_MISSING_LOGGED_IN_KEY) {
+    $messages[] = 'Error: Add WP_LOGGED_IN_KEY variable to the list of variables - via the .env file or by other means.';
+  }
+
+  if (defined('WP_MISSING_NONCE_KEY') && WP_MISSING_NONCE_KEY) {
+    $messages[] = 'Error: Add WP_NONCE_KEY variable to the list of variables - via the .env file or by other means.';
+  }
+
+  if (defined('WP_MISSING_AUTH_SALT') && WP_MISSING_AUTH_SALT) {
+    $messages[] = 'Error: Add WP_AUTH_SALT variable to the list of variables - via the .env file or by other means.';
+  }
+
+  if (defined('WP_MISSING_SECURE_AUTH_SALT') && WP_MISSING_SECURE_AUTH_SALT) {
+    $messages[] = 'Error: Add WP_SECURE_AUTH_SALT variable to the list of variables - via the .env file or by other means.';
+  }
+
+  if (defined('WP_MISSING_LOGGED_IN_SALT') && WP_MISSING_LOGGED_IN_SALT) {
+    $messages[] = 'Error: Add WP_LOGGED_IN_SALT variable to the list of variables - via the .env file or by other means.';
+  }
+
+  if (defined('WP_MISSING_NONCE_SALT') && WP_MISSING_NONCE_SALT) {
+    $messages[] = 'Error: Add WP_NONCE_SALT variable to the list of variables - via the .env file or by other means.';
+  }
+
+  foreach ($messages as $message) {
+    echo '<div class="notice notice-error"><p>' . $message . '</p></div>';
+  }
+
+}
+
+add_action('admin_notices', 'show_env_var_admin_notice');

--- a/web/content/mu-plugins/wp_lagoon_configuration.php
+++ b/web/content/mu-plugins/wp_lagoon_configuration.php
@@ -53,4 +53,4 @@ function wp_lagoon_config_admin_notices() {
 
 }
 
-add_action('admin_notices', 'show_env_var_admin_notice');
+add_action('admin_notices', 'wp_lagoon_config_admin_notices');

--- a/web/wp-config.php
+++ b/web/wp-config.php
@@ -115,14 +115,61 @@ define('DB_COLLATE', '');
  *
  * @since 2.6.0
  */
-define( 'AUTH_KEY',         'put your unique phrase here' );
-define( 'SECURE_AUTH_KEY',  'put your unique phrase here' );
-define( 'LOGGED_IN_KEY',    'put your unique phrase here' );
-define( 'NONCE_KEY',        'put your unique phrase here' );
-define( 'AUTH_SALT',        'put your unique phrase here' );
-define( 'SECURE_AUTH_SALT', 'put your unique phrase here' );
-define( 'LOGGED_IN_SALT',   'put your unique phrase here' );
-define( 'NONCE_SALT',       'put your unique phrase here' );
+if (getenv('WP_AUTH_KEY')) {
+  define( 'AUTH_KEY', getenv('WP_AUTH_KEY'));
+}
+else {
+  define( 'WP_MISSING_AUTH_KEY', true);
+}
+
+if (getenv('WP_SECURE_AUTH_KEY')) {
+  define( 'SECURE_AUTH_KEY',  getenv('WP_SECURE_AUTH_KEY'));
+}
+else {
+  define( 'WP_MISSING_SECURE_AUTH_KEY', true);
+}
+
+if (getenv('WP_LOGGED_IN_KEY')) {
+  define( 'LOGGED_IN_KEY', getenv('WP_LOGGED_IN_KEY'));
+}
+else {
+  define( 'WP_MISSING_LOGGED_IN_KEY', true);
+}
+
+if (getenv('WP_NONCE_KEY')) {
+  define( 'NONCE_KEY', getenv('WP_NONCE_KEY'));
+}
+else {
+  define( 'WP_MISSING_NONCE_KEY', true);
+}
+
+if (getenv('WP_AUTH_SALT')) {
+  define( 'AUTH_SALT', getenv('WP_AUTH_SALT'));
+}
+else {
+  define( 'WP_MISSING_AUTH_SALT', true);
+}
+
+if (getenv('WP_SECURE_AUTH_SALT')) {
+  define( 'SECURE_AUTH_SALT', getenv('WP_SECURE_AUTH_SALT'));
+}
+else {
+  define( 'WP_MISSING_SECURE_AUTH_SALT', true);
+}
+
+if (getenv('WP_LOGGED_IN_SALT')) {
+  define( 'LOGGED_IN_SALT', getenv('WP_LOGGED_IN_SALT'));
+}
+else {
+  define( 'WP_MISSING_LOGGED_IN_SALT', true);
+}
+
+if (getenv('WP_NONCE_SALT')) {
+  define( 'NONCE_SALT', getenv('WP_NONCE_SALT'));
+}
+else {
+  define( 'WP_MISSING_NONCE_SALT', true);
+}
 
 /**#@-*/
 


### PR DESCRIPTION
Updated default Wordpress hashes to rely on environment variables and provide default message if variables not found.