### PR TITLE
Add MySQL 8.0 compatibility plugin and update project configurations

### DIFF
--- a/.ahoy.yml
+++ b/.ahoy.yml
@@ -4,7 +4,11 @@ ahoyapi: v2
 commands:
   up:
     usage: Build project.
-    cmd: docker-compose up -d "$@"
+    cmd: |
+      if [ -f .env ]; then
+        export $(cat .env | grep -v '^#' | xargs)
+      fi
+      docker compose up -d "$@"
 
   down:
     usage: Delete project (CAUTION).
@@ -23,37 +27,43 @@ commands:
     usage: Stop Docker containers and remove container, images, volumes and networks.
     cmd: |
       if [ -f "docker-compose.yml" ]; then
-        docker-compose down --volumes
+        docker compose down --volumes
       fi
       rm -rf ./vendor
 
   build:
     usage: Build project.
     cmd: |
-      docker-compose up -d --build --force-recreate "$@"
+      if [ -f .env ]; then
+        export $(cat .env | grep -v '^#' | xargs)
+      fi
+      docker compose up -d --build --force-recreate "$@"
 
   build-containers:
     usage: Build containers using dockerfiles.
     cmd: |
-      docker build -t salsadigitalau/wordpress-lagoon:latest -f Dockerfile.cli .
+      if [ -f .env ]; then
+        export $(cat .env | grep -v '^#' | xargs)
+      fi
+      docker build -t salsadigital/wordpress-lagoon-cli:latest -f Dockerfile.cli .
 
   push-containers:
     usage: Push containers to the remote repository.
     cmd: |
-      docker push salsadigitalau/wordpress-lagoon:latest
+      docker push salsadigital/wordpress-lagoon-cli:latest
 
   install-site:
     usage: Install a vanilla Wordpress site.
     cmd: |
       echo "Installing a vanilla Wordpress site as $LOCALDEV_URL"
-      docker-compose exec -T cli \
+      docker compose exec -T cli \
               composer install --no-dev -n --prefer-dist --working-dir=/app
-      docker-compose exec -T cli \
+      docker compose exec -T cli \
         wp db reset --yes \
           --path=/app/${WEBROOT}/wp \
           --url=$LOCALDEV_URL \
           --allow-root
-      docker-compose exec -T cli \
+      docker compose exec -T cli \
         wp core install \
         --allow-root \
         --url=$LOCALDEV_URL \
@@ -66,15 +76,15 @@ commands:
 
   cli:
     usage: Start a shell inside TEST container.
-    cmd: docker-compose exec cli bash
+    cmd: docker compose exec cli bash
 
   run:
     usage: Run command inside TEST container.
-    cmd: docker-compose exec -T cli bash -c "$@"
+    cmd: docker compose exec -T cli bash -c "$@"
 
   wp:
     usage: Run wp-cli commands in TEST container.
-    cmd: docker-compose exec -T cli wp --allow-root --path=/app/web/wp "$@"
+    cmd: docker compose exec -T cli wp --allow-root --path=/app/web/wp "$@"
 
   composer:
     usage: Runs composer inside conainer
@@ -82,38 +92,38 @@ commands:
 
   logs:
     usage: Show Docker logs.
-    cmd: docker-compose logs "$@"
+    cmd: docker compose logs "$@"
 
   ps:
     usage: List running Docker containers.
-    cmd: docker-compose ps | grep ${COMPOSE_PROJECT_NAME}
+    cmd: docker compose ps | grep ${COMPOSE_PROJECT_NAME}
 
   restart:
     usage: Restart Docker containers.
-    cmd: docker-compose restart
+    cmd: docker compose restart
 
   stop:
     usage: Stop Docker containers.
-    cmd: docker-compose stop "$@"
+    cmd: docker compose stop "$@"
 
   mysql-import:
     usage: Pipe in a sql file.  `ahoy mysql-import local.sql`
     cmd: |
       if [ -e "$@" ] ; then
-        docker-compose exec cli bash -c 'wp --path=/app/web/wp db reset --yes' &&
-        docker-compose exec -T cli bash -c 'wp --path=/app/web/wp db query' < "$@" &&
-        docker-compose exec -T cli bash -c 'wp --path=/app/web/wp option update blogname "$COMPOSE_PROJECT_NAME $LAGOON_ENVIRONMENT_TYPE"'
+        docker compose exec cli bash -c 'wp --path=/app/web/wp db reset --yes' &&
+        docker compose exec -T cli bash -c 'wp --path=/app/web/wp db query' < "$@" &&
+        docker compose exec -T cli bash -c 'wp --path=/app/web/wp option update blogname "$COMPOSE_PROJECT_NAME $LAGOON_ENVIRONMENT_TYPE"'
       else
         echo "Provided sql file" "$@" "does not exist"
       fi
 
   mysql-dump:
     usage: Dump data out into a file. `ahoy wp db export local.sql"`
-    cmd: docker-compose exec cli bash -c 'wp db export --add-drop-table --path=/app/web/wp "$@"'
+    cmd: docker compose exec cli bash -c 'wp db export --add-drop-table --path=/app/web/wp "$@"'
 
   backup:
     usage: Backup database into the persistent volume content/uploads/backups
-    cmd: docker-compose exec cli bash -c 'wp db export --add-drop-table --path=/app/web/wp - | gzip > /app/web/content/uploads/backups/pre-deploy-backup-`date +%Y-%m-%d-%T`.db.sql.gz'
+    cmd: docker compose exec cli bash -c 'wp db export --add-drop-table --path=/app/web/wp - | gzip > /app/web/content/uploads/backups/pre-deploy-backup-`date +%Y-%m-%d-%T`.db.sql.gz'
 
   refresh-db:
     usage: Loads database files from .data/db.sql and imports into container
@@ -143,9 +153,20 @@ entrypoint:
   - "-c"
   - "-e"
   - |
-    [ -f .env ] && [ -s .env ] && export $(grep -v '^#' .env | xargs) && if [ -f .env.local ] && [ -s .env.local ]; then export $(grep -v '^#' .env.local | xargs); fi
+    if [ -f .env ]; then
+      set -a
+      source .env
+      set +a
+    fi
+    if [ -f .env.local ]; then
+      set -a
+      source .env.local
+      set +a
+    fi
     export APP=${APP:-/app}
     export WEBROOT=${WEBROOT:-web}
+    export PHP_VERSION=${PHP_VERSION:-8.3}
+    export WP_VERSION=${WP_VERSION:-6.6.2}
     bash -e -c "$0" "$@"
   - '{{cmd}}'
   - '{{name}}'

--- a/.docker/Dockerfile.nginx
+++ b/.docker/Dockerfile.nginx
@@ -1,6 +1,6 @@
 ARG WP_VERSION
 ARG PHP_VERSION
-FROM salsadigitalau/wordpress-lagoon:wp-${WP_VERSION}-php-${PHP_VERSION} as builder
+FROM salsadigital/wordpress-lagoon-cli:wp-${WP_VERSION}-php-${PHP_VERSION} AS builder
 
 FROM uselagoon/nginx:24.10.0
 

--- a/.env
+++ b/.env
@@ -3,7 +3,7 @@
 #
 # It is used by Ahoy and other scripts to read default values.
 #
-# Copy this file to '.env' to make docker-compose use overridden values.
+# Copy this file to '.env' to make docker compose use overridden values.
 
 # Current site name. All containers will have this prefix.
 COMPOSE_PROJECT_NAME=wordpress-nginx
@@ -51,6 +51,9 @@ WP_NONCE_SALT=define_here
 
 # PHP version for all containers
 PHP_VERSION=8.3
+
+# WordPress version for all containers
+WP_VERSION=6.6.2
 
 MYSQL_COLLATION=utf8mb4_general_ci
 MYSQL_INNODB_BUFFER_POOL_SIZE=512M

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -32,10 +32,10 @@ jobs:
             echo "WP_VERSION=${BASH_REMATCH[1]}" >> $GITHUB_OUTPUT
             echo "PHP_VERSION=${BASH_REMATCH[2]}" >> $GITHUB_OUTPUT
           elif [[ "${{ github.ref }}" =~ ^refs/heads/php-([0-9]+\.[0-9]+)$ ]]; then
-            echo "WP_VERSION=6.4.3" >> $GITHUB_OUTPUT
+            echo "WP_VERSION=6.6.2" >> $GITHUB_OUTPUT
             echo "PHP_VERSION=${BASH_REMATCH[1]}" >> $GITHUB_OUTPUT
           else
-            echo "WP_VERSION=6.4.3" >> $GITHUB_OUTPUT
+            echo "WP_VERSION=6.6.2" >> $GITHUB_OUTPUT
             echo "PHP_VERSION=8.3" >> $GITHUB_OUTPUT
           fi
 

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 vendor
 web
 !web/content/plugins
+!web/content/plugins/**
 !web/content/themes/.gitkeep
 !web/content/mu-plugins/load.php
 .idea

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '2.3'
-
 x-lagoon-project:
   # Lagoon project name (leave `&lagoon-project` when you edit this)
   &lagoon-project wordpress-nginx
@@ -23,7 +21,7 @@ x-environment:
     LAGOON_ENVIRONMENT_TYPE: production
     LAGOON_FEATURE_FLAG_ROOTLESS_WORKLOAD: ${LAGOON_FEATURE_FLAG_ROOTLESS_WORKLOAD:-enabled}
     WEBROOT: ${WEBROOT:-web}
-    # Uncomment to enable xdebug and then restart via `docker-compose up -d`
+    # Uncomment to enable xdebug and then restart via `docker compose up -d`
     # XDEBUG_ENABLE: "true"
     PHP_VERSION: ${PHP_VERSION:-8.3}
     # Local database host (not used in production).
@@ -65,12 +63,15 @@ services:
     build:
       context: .
       dockerfile: .docker/Dockerfile.nginx
+      args:
+        WP_VERSION: ${WP_VERSION:-6.6.2}
+        PHP_VERSION: ${PHP_VERSION:-8.3}
     labels:
       lagoon.type: nginx-php-persistent
       lagoon.persistent: /app/web/content/uploads/ # define where the persistent storage should be mounted too
     << : *default-volumes # loads the defined volumes from the top
     depends_on:
-      - cli # basically just tells docker-compose to build the cli first
+      - cli # basically just tells docker compose to build the cli first
     environment:
       << : *default-environment # loads the defined environment variables from the top
     networks:
@@ -85,13 +86,14 @@ services:
         CLI_IMAGE: *lagoon-project
         IMAGE_VERSION: *image-version
         PHP_VERSION: ${PHP_VERSION:-8.3}
+        WP_VERSION: ${WP_VERSION:-6.6.2}
     labels:
       lagoon.type: nginx-php-persistent
       lagoon.name: nginx # we want this service be part of the nginx pod in Lagoon
       lagoon.persistent: /app/web/content/uploads/ # define where the persistent storage should be mounted too
     << : *default-volumes # loads the defined volumes from the top
     depends_on:
-      - cli # basically just tells docker-compose to build the cli first
+      - cli # basically just tells docker compose to build the cli first
     environment:
       << : *default-environment # loads the defined environment variables from the top
 
@@ -100,7 +102,7 @@ services:
     labels:
       lagoon.type: mariadb
     ports:
-      - "3306" # exposes the port 3306 with a random local port, find it with `docker-compose port mariadb 3306`
+      - "3306" # exposes the port 3306 with a random local port, find it with `docker compose port mariadb 3306`
     environment:
       << : *default-environment
 

--- a/web/content/plugins/salsa_mysql8_upgrade/README.md
+++ b/web/content/plugins/salsa_mysql8_upgrade/README.md
@@ -1,0 +1,42 @@
+# Salsa MySQL 8 Upgrade
+
+A WordPress plugin that monitors and reports database collation status, ensuring utf8mb4_general_ci compatibility.
+
+## Description
+
+This plugin adds a new check to the WordPress Site Health page that verifies if all database tables are using the recommended `utf8mb4_general_ci` collation. This is important for ensuring proper character encoding and sorting in MySQL 8.
+
+## Features
+
+- Adds a new check to WordPress Site Health
+- Monitors database table collations
+- Reports tables using non-standard collations
+- Provides clear status indicators and recommendations
+
+## Installation
+
+1. Upload the `salsa_mysql8_upgrade` directory to the `/wp-content/plugins/` directory
+2. Activate the plugin through the 'Plugins' menu in WordPress
+3. Visit Tools > Site Health to see the database collation status
+
+## Usage
+
+1. Navigate to Tools > Site Health in your WordPress admin panel
+2. Look for the "Database Tables Collation" check in the Status tab
+3. The check will show:
+   - A "good" status if all tables use utf8mb4_general_ci
+   - A "critical" status if any tables use different collations, with a list of affected tables
+
+## Requirements
+
+- WordPress 5.2 or higher
+- PHP 8.3 or higher
+- MySQL 8.0 or higher
+
+## Support
+
+For support, please create an issue in the plugin's repository.
+
+## License
+
+GPL-2.0+ 

--- a/web/content/plugins/salsa_mysql8_upgrade/salsa_mysql8_upgrade.php
+++ b/web/content/plugins/salsa_mysql8_upgrade/salsa_mysql8_upgrade.php
@@ -1,0 +1,107 @@
+<?php
+/**
+ * Plugin Name: Salsa MySQL 8 Upgrade
+ * Plugin URI: https://salsa.digital
+ * Description: Monitors and reports database collation status, ensuring utf8mb4_general_ci compatibility.
+ * Version: 1.0.0
+ * Author: Salsa Digital
+ * Author URI: https://salsa.digital
+ * License: GPL-2.0+
+ */
+
+declare(strict_types=1);
+
+// If this file is called directly, abort.
+if (!defined('WPINC')) {
+    die;
+}
+
+class Salsa_MySQL8_Upgrade {
+    private const TARGET_COLLATION = 'utf8mb4_general_ci';
+    private static $instance = null;
+
+    public static function get_instance() {
+        if (null === self::$instance) {
+            self::$instance = new self();
+        }
+        return self::$instance;
+    }
+
+    private function __construct() {
+        add_filter('site_status_tests', [$this, 'register_site_status_tests']);
+    }
+
+    public function register_site_status_tests($tests) {
+        $tests['direct']['salsa_mysql8_collation'] = [
+            'label' => __('Database Collation Check', 'salsa_mysql8_upgrade'),
+            'test'  => [$this, 'check_database_collation']
+        ];
+        return $tests;
+    }
+
+    public function check_database_collation() {
+        global $wpdb;
+
+        // Get tables with different collation
+        $query = $wpdb->prepare(
+            "SHOW TABLE STATUS WHERE Collation <> %s",
+            self::TARGET_COLLATION
+        );
+        $tables = $wpdb->get_results($query);
+        $table_count = count($tables);
+
+        $result = [
+            'label'       => __('Database Tables Collation', 'salsa_mysql8_upgrade'),
+            'status'      => 'good',
+            'badge'       => [
+                'label' => __('Performance', 'salsa_mysql8_upgrade'),
+                'color' => 'blue',
+            ],
+            'description' => sprintf(
+                '<p>%s</p>',
+                __('All database tables are using the recommended utf8mb4_general_ci collation.', 'salsa_mysql8_upgrade')
+            ),
+            'actions'     => '',
+            'test'        => 'salsa_mysql8_collation',
+        ];
+
+        if ($table_count > 0) {
+            $table_list = [];
+            foreach ($tables as $table) {
+                $table_list[] = $table->Name . ' (' . $table->Collation . ')';
+            }
+
+            $result['status'] = 'critical';
+            $result['badge']['color'] = 'red';
+            $result['description'] = sprintf(
+                '<p>%s</p><p>%s</p>',
+                sprintf(
+                    __('Found %d tables with non-standard collation:', 'salsa_mysql8_upgrade'),
+                    $table_count
+                ),
+                implode(', ', $table_list)
+            );
+            $result['actions'] = sprintf(
+                '<p>%s</p>',
+                __('Please contact your database administrator to update the table collations to utf8mb4_general_ci.', 'salsa_mysql8_upgrade')
+            );
+        }
+
+        return $result;
+    }
+
+    public static function activate() {
+        // Activation code if needed
+    }
+
+    public static function deactivate() {
+        // Deactivation code if needed
+    }
+}
+
+// Initialize the plugin
+add_action('plugins_loaded', ['Salsa_MySQL8_Upgrade', 'get_instance']);
+
+// Register activation and deactivation hooks
+register_activation_hook(__FILE__, ['Salsa_MySQL8_Upgrade', 'activate']);
+register_deactivation_hook(__FILE__, ['Salsa_MySQL8_Upgrade', 'deactivate']); 


### PR DESCRIPTION
- Created new Salsa MySQL 8 Upgrade plugin to monitor database collation
- Updated docker-compose and Dockerfile configurations
- Migrated from docker-compose to docker compose commands
- Updated PHP and WordPress versions to 8.3 and 6.6.2
- Modified .env and .ahoy.yml to support new configurations
- Updated GitHub workflow to use latest WordPress version

## Checklist before requesting a review

- [ ] I have formatted the subject to include ticket number as `[YSCODE-123] Verb in past tense with dot at the end.`
- [ ] I have added a link to the issue tracker
- [x] I have provided information in `Changed` section about WHY something was done if this was not a normal implementation
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run new and existing relevant tests locally with my changes, and they passed
- [ ] I have provided screenshots, where applicable

## Changed

1. Docker and Environment Updates:
   - Updated Docker commands from `docker-compose` to `docker compose` (new syntax)
   - Added proper environment variable loading in .ahoy.yml
   - Updated Docker image references from `salsadigitalau` to `salsadigital`
   - Added WordPress version (WP_VERSION=6.6.2) to environment configuration
   - Updated WordPress core version from 6.4.3 to 6.6.2 in build workflows

2. Git Configuration:
   - Updated .gitignore to properly track plugin files:
     ```diff
     !web/content/plugins
     +!web/content/plugins/**
     ```

3. New Plugin: Salsa MySQL 8 Upgrade
   - Added new plugin for monitoring database collation status
   - Features:
     - Site Health integration for database collation checks
     - Monitors for utf8mb4_general_ci compatibility
     - Reports non-compliant table collations
   - Requirements:
     - WordPress 5.2+
     - PHP 8.3+
     - MySQL 8.0+

4. Docker Compose Updates:
   - Removed version '2.3' specification for newer Docker Compose compatibility
   - Added WP_VERSION and PHP_VERSION args to nginx service
   - Updated service dependencies documentation

## Testing Steps

1. Build and start containers:
   ```bash
   ahoy build
   ```

2. Verify plugin installation:
   ```bash
   ahoy wp plugin status salsa_mysql8_upgrade
   ```

3. Check Site Health in WordPress admin:
   - Navigate to Tools > Site Health
   - Verify "Database Tables Collation" check is present
   - Confirm collation status is reported correctly

## Related Documentation
- [Docker Compose V2 Migration](https://docs.docker.com/compose/migrate/)
- [WordPress Site Health API](https://developer.wordpress.org/plugins/site-health/custom-site-health-checks/)

## Screenshots
