### PR TITLE
Update Lagoon Docker image versions to 25.1.0

### DIFF
--- a/.docker/Dockerfile.cli
+++ b/.docker/Dockerfile.cli
@@ -1,5 +1,5 @@
 ARG PHP_VERSION=8.3
-FROM uselagoon/php-${PHP_VERSION}-cli:24.10.0
+FROM uselagoon/php-${PHP_VERSION}-cli:25.1.0
 
 RUN apk update \
     && apk add --no-cache \

--- a/.docker/Dockerfile.nginx
+++ b/.docker/Dockerfile.nginx
@@ -2,7 +2,7 @@ ARG WP_VERSION
 ARG PHP_VERSION
 FROM salsadigital/wordpress-lagoon-cli:wp-${WP_VERSION}-php-${PHP_VERSION} AS builder
 
-FROM uselagoon/nginx:24.10.0
+FROM uselagoon/nginx:25.1.0
 
 RUN apk add --no-cache tzdata
 

--- a/.docker/Dockerfile.php
+++ b/.docker/Dockerfile.php
@@ -3,7 +3,7 @@ ARG PHP_VERSION=8.3
 
 FROM ${CLI_IMAGE} as cli
 
-FROM uselagoon/php-${PHP_VERSION}-fpm:24.10.0
+FROM uselagoon/php-${PHP_VERSION}-fpm:25.1.0
 
 RUN apk update \
     && apk add --no-cache \


### PR DESCRIPTION
- Upgraded uselagoon Docker images for CLI, Nginx, and PHP
- Updated image tags from 24.10.0 to 25.1.0

## Checklist before requesting a review

- [ ] I have formatted the subject to include ticket number as `[YSCODE-123] Verb in past tense with dot at the end.`
- [ ] I have added a link to the issue tracker
- [x] I have provided information in `Changed` section about WHY something was done if this was not a normal implementation
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run new and existing relevant tests locally with my changes, and they passed
- [ ] I have provided screenshots, where applicable

## Changed

1. Updated Lagoon Docker Images to Latest Version (24.10.0 → 25.1.0):
   ```diff
   # CLI Image
   - FROM uselagoon/php-${PHP_VERSION}-cli:24.10.0
   + FROM uselagoon/php-${PHP_VERSION}-cli:25.1.0

   # Nginx Image
   - FROM uselagoon/nginx:24.10.0
   + FROM uselagoon/nginx:25.1.0

   # PHP-FPM Image
   - FROM uselagoon/php-${PHP_VERSION}-fpm:24.10.0
   + FROM uselagoon/php-${PHP_VERSION}-fpm:25.1.0
   ```

## Testing Steps

1. Rebuild containers with new images:
   ```bash
   docker compose down
   docker compose build --no-cache
   docker compose up -d
   ```

2. Verify all services are running:
   ```bash
   docker compose ps
   ```

3. Check WordPress is functioning correctly:
   - Frontend loads without errors
   - Admin interface is accessible
   - PHP processing works (try saving settings)

## Related Documentation
- [Lagoon Images Changelog](https://uselagoon.github.io/lagoon/releases/)
- [Lagoon 25.1.0 Release Notes](https://uselagoon.github.io/lagoon/releases/2024_01_release_notes/)

## Screenshots
